### PR TITLE
fix encoding issue by define what type of encoding used

### DIFF
--- a/optionsbleed
+++ b/optionsbleed
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 # Optionsbleed proof of concept test
 # by Hanno Böck


### PR DESCRIPTION
Python throws error because code encoding not specified.

`SyntaxError: Non-ASCII character '\xc3' in file optionsbleed on line 4, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details`

so adding encoding will be a good idea.

